### PR TITLE
Fix linter file

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,7 @@
     "prefer-arrow-callback": "off",
     "func-names": "off",
     "no-param-reassign": "off",
-    "max-lines-per-function": "off",
+    "max-lines-per-function": "off"
   },
   "env": {
     "browser": true,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,6 @@
     "func-names": "off",
     "no-param-reassign": "off",
     "max-lines-per-function": "off",
-    "no-unused-vars": "warn"
   },
   "env": {
     "browser": true,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,8 @@
     "prefer-arrow-callback": "off",
     "func-names": "off",
     "no-param-reassign": "off",
-    "max-lines-per-function": "off"
+    "max-lines-per-function": "off",
+    "no-unused-vars": "warn"
   },
   "env": {
     "browser": true,

--- a/test/asyncJest.spec.js
+++ b/test/asyncJest.spec.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const answerPhone = require('../src/asyncJest');
+// const answerPhone = require('../src/asyncJest');
 /*
 A função answerPhone recebe um parâmetro boleano.
 Dependendo do parâmetro o retorno da função varia, veja a função no arquivo 'src/asyncJest.js'


### PR DESCRIPTION
Renomeia arquivo .eslintrc para .eslintrc.json e adiciona regra para transformar em warning o erro de variáveis não utilizadas para que o avaliador possa ser executado corretamente mesmo antes das pessoas estudantes começarem a executar o projeto.